### PR TITLE
Correção de componentes telas e validações

### DIFF
--- a/LocadoraDeVeiculos.Dominio/Compartilhado/RuleBuilderExtensions.cs
+++ b/LocadoraDeVeiculos.Dominio/Compartilhado/RuleBuilderExtensions.cs
@@ -21,14 +21,6 @@ namespace LocadoraDeVeiculos.Dominio.Compartilhado
             return options;
         }
 
-        public static IRuleBuilder<T, string> Nome<T>(this IRuleBuilder<T, string> ruleBuilder)
-        {
-            var options = ruleBuilder
-                         .MinimumLength(2)
-                         .Matches(@"^[a-zA-Zà-úÀ-ÚçÇ ]+$");
-            return options;
-        }
-
         public static IRuleBuilder<T, string> Endereco<T>(this IRuleBuilder<T, string> ruleBuilder)
         {
             var options = ruleBuilder

--- a/LocadoraDeVeiculos.Dominio/ModuloCliente/ValidadorCliente.cs
+++ b/LocadoraDeVeiculos.Dominio/ModuloCliente/ValidadorCliente.cs
@@ -16,18 +16,6 @@ namespace LocadoraDeVeiculos.Dominio.ModuloCliente
                 .NotNull().NotEmpty()
                 .Nomes();
 
-            RuleFor(x => x.Email)
-                .NotNull().NotEmpty()
-                .EmailAddress();
-
-            RuleFor(x => x.Telefone)
-                .NotNull().NotEmpty()
-                .Telefone();
-
-            RuleFor(x => x.Endereco)
-                .NotNull().NotEmpty()
-                .Endereco();
-
             When(x => x.TipoCliente == TipoCliente.PessoaJuridica, () =>
             {
                 RuleFor(x => x.CNPJ)
@@ -42,6 +30,18 @@ namespace LocadoraDeVeiculos.Dominio.ModuloCliente
                 .NotNull().NotEmpty()
                 .CPF();
             });
+
+            RuleFor(x => x.Email)
+                .NotNull().NotEmpty()
+                .EmailAddress();
+
+            RuleFor(x => x.Telefone)
+                .NotNull().NotEmpty()
+                .Telefone();
+
+            RuleFor(x => x.Endereco)
+                .NotNull().NotEmpty()
+                .Endereco();
         }
     }
 }

--- a/LocadoraDeVeiculos.Dominio/ModuloFuncionario/ValidadorFuncionario.cs
+++ b/LocadoraDeVeiculos.Dominio/ModuloFuncionario/ValidadorFuncionario.cs
@@ -17,13 +17,13 @@ namespace LocadoraDeVeiculos.Dominio.ModuloFuncionario
                 .NotNull().NotEmpty()
                 .Nomes();
 
-            RuleFor(x => x.Email)
-                .NotNull().NotEmpty()
-                .EmailAddress();
-
             RuleFor(x => x.Telefone)
                 .NotNull().NotEmpty()
                 .Telefone();
+
+            RuleFor(x => x.Email)
+                .NotNull().NotEmpty()
+                .EmailAddress();
 
             RuleFor(x => x.Endereco)
                 .NotNull().NotEmpty()

--- a/LocadoraDeVeiculos.Dominio/ModuloGrupoVeiculos/ValidadorGrupoVeiculos.cs
+++ b/LocadoraDeVeiculos.Dominio/ModuloGrupoVeiculos/ValidadorGrupoVeiculos.cs
@@ -14,9 +14,8 @@ namespace LocadoraDeVeiculos.Dominio.ModuloGruposVeiculos
         public ValidadorGrupoVeiculos()
         {
             RuleFor(x => x.Nome)
-                    .NotNull().NotEmpty()
-                    .MinimumLength(2)
-                    .Nome();
+                .NotNull().NotEmpty()
+                .Nomes();
         }
     }
 }

--- a/LocadoraDeVeiculos.Dominio/ModuloTaxas/ValidadorTaxa.cs
+++ b/LocadoraDeVeiculos.Dominio/ModuloTaxas/ValidadorTaxa.cs
@@ -10,13 +10,10 @@ namespace LocadoraDeVeiculos.Dominio.ModuloTaxas
 {
     public class ValidadorTaxa : AbstractValidator<Taxa>
     {
-        //acrescentar as regras do jamboard de validação
-        
         public ValidadorTaxa()
         {
             RuleFor(x => x.Descricao)
                 .NotNull().NotEmpty()
-                .MinimumLength(2)
                 .Nomes();
             
 

--- a/LocadoraDeVeiculos.WinApp/ModuloCliente/TelaCadastroClientesForm.Designer.cs
+++ b/LocadoraDeVeiculos.WinApp/ModuloCliente/TelaCadastroClientesForm.Designer.cs
@@ -254,6 +254,7 @@
             this.Controls.Add(this.label4);
             this.Controls.Add(this.label2);
             this.Controls.Add(this.label1);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "TelaCadastroClientesForm";

--- a/LocadoraDeVeiculos.WinApp/ModuloCondutor/TelaCadastroCondutorForm.cs
+++ b/LocadoraDeVeiculos.WinApp/ModuloCondutor/TelaCadastroCondutorForm.cs
@@ -66,6 +66,14 @@ namespace LocadoraDeVeiculos.WinApp.ModuloCondutor
             condutor.CNH = txtCNH.Text;
             condutor.ValidadeCNH = datePickerValidadeCNH.Value;
 
+            if (cmbClientes.SelectedItem == null)
+            {
+                string erro = "Não pode inserir um condutor sem selecionar um cliente";
+                TelaPrincipalForm.Instancia.AtualizarRodape(erro);
+                DialogResult = DialogResult.None;
+                return;
+            }
+
             var cliente_selecionado = (Cliente)cmbClientes.SelectedItem;
             condutor.Cliente_Id = cliente_selecionado.Id;
 

--- a/LocadoraDeVeiculos.WinApp/ModuloFuncionario/TelaCadastroFuncionariosForm.Designer.cs
+++ b/LocadoraDeVeiculos.WinApp/ModuloFuncionario/TelaCadastroFuncionariosForm.Designer.cs
@@ -62,12 +62,13 @@
             // txtNumero
             // 
             this.txtNumero.BackColor = System.Drawing.Color.White;
+            this.txtNumero.Enabled = false;
             this.txtNumero.Location = new System.Drawing.Point(89, 13);
             this.txtNumero.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.txtNumero.Name = "txtNumero";
             this.txtNumero.ReadOnly = true;
             this.txtNumero.Size = new System.Drawing.Size(76, 27);
-            this.txtNumero.TabIndex = 44;
+            this.txtNumero.TabIndex = 1;
             // 
             // txtEmail
             // 
@@ -282,12 +283,13 @@
             this.Controls.Add(this.label2);
             this.Controls.Add(this.label4);
             this.Controls.Add(this.label1);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "TelaCadastroFuncionariosForm";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Cadastro de Funcionários";
             ((System.ComponentModel.ISupportInitialize)(this.txtSalario)).EndInit();
             this.ResumeLayout(false);

--- a/LocadoraDeVeiculos.WinApp/ModuloGrupoVeiculos/TelaCadastroGrupoVeiculosForm.Designer.cs
+++ b/LocadoraDeVeiculos.WinApp/ModuloGrupoVeiculos/TelaCadastroGrupoVeiculosForm.Designer.cs
@@ -43,7 +43,7 @@
             this.buttonGravarGrupoVeiculos.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.buttonGravarGrupoVeiculos.Name = "buttonGravarGrupoVeiculos";
             this.buttonGravarGrupoVeiculos.Size = new System.Drawing.Size(86, 31);
-            this.buttonGravarGrupoVeiculos.TabIndex = 0;
+            this.buttonGravarGrupoVeiculos.TabIndex = 2;
             this.buttonGravarGrupoVeiculos.Text = "Gravar";
             this.buttonGravarGrupoVeiculos.UseVisualStyleBackColor = true;
             this.buttonGravarGrupoVeiculos.Click += new System.EventHandler(this.buttonGravarGrupoVeiculos_Click_1);
@@ -55,7 +55,7 @@
             this.buttonCancelarGrupoVeiculos.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.buttonCancelarGrupoVeiculos.Name = "buttonCancelarGrupoVeiculos";
             this.buttonCancelarGrupoVeiculos.Size = new System.Drawing.Size(86, 31);
-            this.buttonCancelarGrupoVeiculos.TabIndex = 1;
+            this.buttonCancelarGrupoVeiculos.TabIndex = 3;
             this.buttonCancelarGrupoVeiculos.Text = "Cancelar";
             this.buttonCancelarGrupoVeiculos.UseVisualStyleBackColor = true;
             // 
@@ -74,7 +74,7 @@
             this.textBoxNomeGrupoVeiculos.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.textBoxNomeGrupoVeiculos.Name = "textBoxNomeGrupoVeiculos";
             this.textBoxNomeGrupoVeiculos.Size = new System.Drawing.Size(230, 27);
-            this.textBoxNomeGrupoVeiculos.TabIndex = 3;
+            this.textBoxNomeGrupoVeiculos.TabIndex = 1;
             // 
             // txtNumero
             // 
@@ -82,6 +82,7 @@
             this.txtNumero.Location = new System.Drawing.Point(100, 6);
             this.txtNumero.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.txtNumero.Name = "txtNumero";
+            this.txtNumero.ReadOnly = true;
             this.txtNumero.Size = new System.Drawing.Size(34, 27);
             this.txtNumero.TabIndex = 17;
             // 
@@ -107,8 +108,11 @@
             this.Controls.Add(this.buttonGravarGrupoVeiculos);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
             this.Name = "TelaCadastroGrupoVeiculosForm";
             this.ShowIcon = false;
+            this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Cadastro Grupo Veiculos";
             this.ResumeLayout(false);

--- a/LocadoraDeVeiculos.WinApp/ModuloTaxas/TelaCadastroTaxaForm.Designer.cs
+++ b/LocadoraDeVeiculos.WinApp/ModuloTaxas/TelaCadastroTaxaForm.Designer.cs
@@ -45,35 +45,37 @@
             // labelDescricaoTaxa
             // 
             this.labelDescricaoTaxa.AutoSize = true;
-            this.labelDescricaoTaxa.Location = new System.Drawing.Point(42, 62);
+            this.labelDescricaoTaxa.Location = new System.Drawing.Point(48, 83);
             this.labelDescricaoTaxa.Name = "labelDescricaoTaxa";
-            this.labelDescricaoTaxa.Size = new System.Drawing.Size(61, 15);
+            this.labelDescricaoTaxa.Size = new System.Drawing.Size(77, 20);
             this.labelDescricaoTaxa.TabIndex = 0;
             this.labelDescricaoTaxa.Text = "Descrição:";
             // 
             // labelValorTaxa
             // 
             this.labelValorTaxa.AutoSize = true;
-            this.labelValorTaxa.Location = new System.Drawing.Point(67, 97);
+            this.labelValorTaxa.Location = new System.Drawing.Point(77, 129);
             this.labelValorTaxa.Name = "labelValorTaxa";
-            this.labelValorTaxa.Size = new System.Drawing.Size(36, 15);
+            this.labelValorTaxa.Size = new System.Drawing.Size(46, 20);
             this.labelValorTaxa.TabIndex = 1;
             this.labelValorTaxa.Text = "Valor:";
             // 
             // textBoxDescricaoTaxa
             // 
-            this.textBoxDescricaoTaxa.Location = new System.Drawing.Point(121, 59);
+            this.textBoxDescricaoTaxa.Location = new System.Drawing.Point(138, 79);
+            this.textBoxDescricaoTaxa.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.textBoxDescricaoTaxa.Name = "textBoxDescricaoTaxa";
-            this.textBoxDescricaoTaxa.Size = new System.Drawing.Size(230, 23);
-            this.textBoxDescricaoTaxa.TabIndex = 2;
+            this.textBoxDescricaoTaxa.Size = new System.Drawing.Size(262, 27);
+            this.textBoxDescricaoTaxa.TabIndex = 1;
             // 
             // buttonGravarTaxa
             // 
             this.buttonGravarTaxa.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.buttonGravarTaxa.Location = new System.Drawing.Point(186, 184);
+            this.buttonGravarTaxa.Location = new System.Drawing.Point(213, 245);
+            this.buttonGravarTaxa.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.buttonGravarTaxa.Name = "buttonGravarTaxa";
-            this.buttonGravarTaxa.Size = new System.Drawing.Size(75, 23);
-            this.buttonGravarTaxa.TabIndex = 4;
+            this.buttonGravarTaxa.Size = new System.Drawing.Size(86, 31);
+            this.buttonGravarTaxa.TabIndex = 5;
             this.buttonGravarTaxa.Text = "Gravar";
             this.buttonGravarTaxa.UseVisualStyleBackColor = true;
             this.buttonGravarTaxa.Click += new System.EventHandler(this.buttonGravarTaxa_Click);
@@ -81,34 +83,38 @@
             // buttonCancelarTaxa
             // 
             this.buttonCancelarTaxa.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.buttonCancelarTaxa.Location = new System.Drawing.Point(267, 184);
+            this.buttonCancelarTaxa.Location = new System.Drawing.Point(314, 245);
+            this.buttonCancelarTaxa.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.buttonCancelarTaxa.Name = "buttonCancelarTaxa";
-            this.buttonCancelarTaxa.Size = new System.Drawing.Size(75, 23);
-            this.buttonCancelarTaxa.TabIndex = 5;
+            this.buttonCancelarTaxa.Size = new System.Drawing.Size(86, 31);
+            this.buttonCancelarTaxa.TabIndex = 6;
             this.buttonCancelarTaxa.Text = "Cancelar";
             this.buttonCancelarTaxa.UseVisualStyleBackColor = true;
             // 
             // labelNumeroTaxa
             // 
             this.labelNumeroTaxa.AutoSize = true;
-            this.labelNumeroTaxa.Location = new System.Drawing.Point(49, 24);
+            this.labelNumeroTaxa.Location = new System.Drawing.Point(56, 32);
             this.labelNumeroTaxa.Name = "labelNumeroTaxa";
-            this.labelNumeroTaxa.Size = new System.Drawing.Size(54, 15);
+            this.labelNumeroTaxa.Size = new System.Drawing.Size(66, 20);
             this.labelNumeroTaxa.TabIndex = 6;
             this.labelNumeroTaxa.Text = "Número:";
             // 
             // textBoxNumeroTaxa
             // 
             this.textBoxNumeroTaxa.Enabled = false;
-            this.textBoxNumeroTaxa.Location = new System.Drawing.Point(121, 21);
+            this.textBoxNumeroTaxa.Location = new System.Drawing.Point(138, 28);
+            this.textBoxNumeroTaxa.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.textBoxNumeroTaxa.Name = "textBoxNumeroTaxa";
-            this.textBoxNumeroTaxa.Size = new System.Drawing.Size(29, 23);
+            this.textBoxNumeroTaxa.ReadOnly = true;
+            this.textBoxNumeroTaxa.Size = new System.Drawing.Size(33, 27);
             this.textBoxNumeroTaxa.TabIndex = 7;
             // 
             // txtUpDownValor
             // 
             this.txtUpDownValor.DecimalPlaces = 2;
-            this.txtUpDownValor.Location = new System.Drawing.Point(121, 92);
+            this.txtUpDownValor.Location = new System.Drawing.Point(138, 123);
+            this.txtUpDownValor.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.txtUpDownValor.Maximum = new decimal(new int[] {
             10000000,
             0,
@@ -120,8 +126,8 @@
             0,
             0});
             this.txtUpDownValor.Name = "txtUpDownValor";
-            this.txtUpDownValor.Size = new System.Drawing.Size(230, 23);
-            this.txtUpDownValor.TabIndex = 8;
+            this.txtUpDownValor.Size = new System.Drawing.Size(263, 27);
+            this.txtUpDownValor.TabIndex = 2;
             this.txtUpDownValor.ThousandsSeparator = true;
             this.txtUpDownValor.Value = new decimal(new int[] {
             1,
@@ -132,10 +138,11 @@
             // radioButtonFixo
             // 
             this.radioButtonFixo.AutoSize = true;
-            this.radioButtonFixo.Location = new System.Drawing.Point(186, 137);
+            this.radioButtonFixo.Location = new System.Drawing.Point(213, 183);
+            this.radioButtonFixo.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.radioButtonFixo.Name = "radioButtonFixo";
-            this.radioButtonFixo.Size = new System.Drawing.Size(47, 19);
-            this.radioButtonFixo.TabIndex = 11;
+            this.radioButtonFixo.Size = new System.Drawing.Size(57, 24);
+            this.radioButtonFixo.TabIndex = 4;
             this.radioButtonFixo.TabStop = true;
             this.radioButtonFixo.Text = "Fixo";
             this.radioButtonFixo.UseVisualStyleBackColor = true;
@@ -143,10 +150,11 @@
             // radioButtonDiario
             // 
             this.radioButtonDiario.AutoSize = true;
-            this.radioButtonDiario.Location = new System.Drawing.Point(121, 137);
+            this.radioButtonDiario.Location = new System.Drawing.Point(138, 183);
+            this.radioButtonDiario.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.radioButtonDiario.Name = "radioButtonDiario";
-            this.radioButtonDiario.Size = new System.Drawing.Size(56, 19);
-            this.radioButtonDiario.TabIndex = 10;
+            this.radioButtonDiario.Size = new System.Drawing.Size(71, 24);
+            this.radioButtonDiario.TabIndex = 3;
             this.radioButtonDiario.TabStop = true;
             this.radioButtonDiario.Text = "Diário";
             this.radioButtonDiario.UseVisualStyleBackColor = true;
@@ -154,17 +162,17 @@
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(8, 138);
+            this.label3.Location = new System.Drawing.Point(9, 184);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(95, 15);
+            this.label3.Size = new System.Drawing.Size(120, 20);
             this.label3.TabIndex = 9;
             this.label3.Text = "Tipo de Cálculo: ";
             // 
             // TelaCadastroTaxaForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(373, 221);
+            this.ClientSize = new System.Drawing.Size(426, 295);
             this.Controls.Add(this.radioButtonFixo);
             this.Controls.Add(this.radioButtonDiario);
             this.Controls.Add(this.label3);
@@ -176,7 +184,14 @@
             this.Controls.Add(this.textBoxDescricaoTaxa);
             this.Controls.Add(this.labelValorTaxa);
             this.Controls.Add(this.labelDescricaoTaxa);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
             this.Name = "TelaCadastroTaxaForm";
+            this.ShowIcon = false;
+            this.ShowInTaskbar = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Cadastro de Taxas";
             ((System.ComponentModel.ISupportInitialize)(this.txtUpDownValor)).EndInit();
             this.ResumeLayout(false);

--- a/LocadoraDeVeiculos.WinApp/TelaPrincipalForm.Designer.cs
+++ b/LocadoraDeVeiculos.WinApp/TelaPrincipalForm.Designer.cs
@@ -35,6 +35,8 @@
             this.pessoasFísicasToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.taxasToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.grupoVeículosToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.clienteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.condutorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolbox = new System.Windows.Forms.ToolStrip();
             this.btnInserir = new System.Windows.Forms.ToolStripButton();
             this.btnEditar = new System.Windows.Forms.ToolStripButton();
@@ -53,8 +55,6 @@
             this.statusStrip1 = new System.Windows.Forms.StatusStrip();
             this.labelRodape = new System.Windows.Forms.ToolStripStatusLabel();
             this.panelRegistros = new System.Windows.Forms.Panel();
-            this.clienteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.condutorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.menu.SuspendLayout();
             this.toolbox.SuspendLayout();
             this.statusStrip1.SuspendLayout();
@@ -68,7 +68,7 @@
             this.menu.Location = new System.Drawing.Point(0, 0);
             this.menu.Name = "menu";
             this.menu.Padding = new System.Windows.Forms.Padding(7, 3, 0, 3);
-            this.menu.Size = new System.Drawing.Size(1211, 30);
+            this.menu.Size = new System.Drawing.Size(1168, 30);
             this.menu.TabIndex = 0;
             this.menu.Text = "menuStrip1";
             // 
@@ -89,37 +89,51 @@
             // funcionárioToolStripMenuItem
             // 
             this.funcionárioToolStripMenuItem.Name = "funcionárioToolStripMenuItem";
-            this.funcionárioToolStripMenuItem.Size = new System.Drawing.Size(224, 26);
+            this.funcionárioToolStripMenuItem.Size = new System.Drawing.Size(191, 26);
             this.funcionárioToolStripMenuItem.Text = "Funcionário";
             this.funcionárioToolStripMenuItem.Click += new System.EventHandler(this.funcionárioToolStripMenuItem_Click);
             // 
             // pessoaJurídicaToolStripMenuItem
             // 
             this.pessoaJurídicaToolStripMenuItem.Name = "pessoaJurídicaToolStripMenuItem";
-            this.pessoaJurídicaToolStripMenuItem.Size = new System.Drawing.Size(224, 26);
+            this.pessoaJurídicaToolStripMenuItem.Size = new System.Drawing.Size(191, 26);
             this.pessoaJurídicaToolStripMenuItem.Text = "Pessoa Jurídica";
             this.pessoaJurídicaToolStripMenuItem.Click += new System.EventHandler(this.pessoaJurídicaToolStripMenuItem_Click);
             // 
             // pessoasFísicasToolStripMenuItem
             // 
             this.pessoasFísicasToolStripMenuItem.Name = "pessoasFísicasToolStripMenuItem";
-            this.pessoasFísicasToolStripMenuItem.Size = new System.Drawing.Size(224, 26);
+            this.pessoasFísicasToolStripMenuItem.Size = new System.Drawing.Size(191, 26);
             this.pessoasFísicasToolStripMenuItem.Text = "Pessoa Física";
             this.pessoasFísicasToolStripMenuItem.Click += new System.EventHandler(this.pessoasFísicasToolStripMenuItem_Click);
             // 
             // taxasToolStripMenuItem
             // 
             this.taxasToolStripMenuItem.Name = "taxasToolStripMenuItem";
-            this.taxasToolStripMenuItem.Size = new System.Drawing.Size(224, 26);
+            this.taxasToolStripMenuItem.Size = new System.Drawing.Size(191, 26);
             this.taxasToolStripMenuItem.Text = "Taxas";
             this.taxasToolStripMenuItem.Click += new System.EventHandler(this.taxasToolStripMenuItem_Click);
             // 
             // grupoVeículosToolStripMenuItem
             // 
             this.grupoVeículosToolStripMenuItem.Name = "grupoVeículosToolStripMenuItem";
-            this.grupoVeículosToolStripMenuItem.Size = new System.Drawing.Size(224, 26);
+            this.grupoVeículosToolStripMenuItem.Size = new System.Drawing.Size(191, 26);
             this.grupoVeículosToolStripMenuItem.Text = "Grupo Veículos";
             this.grupoVeículosToolStripMenuItem.Click += new System.EventHandler(this.grupoVeículosToolStripMenuItem_Click);
+            // 
+            // clienteToolStripMenuItem
+            // 
+            this.clienteToolStripMenuItem.Name = "clienteToolStripMenuItem";
+            this.clienteToolStripMenuItem.Size = new System.Drawing.Size(191, 26);
+            this.clienteToolStripMenuItem.Text = "Cliente";
+            this.clienteToolStripMenuItem.Click += new System.EventHandler(this.clienteToolStripMenuItem_Click);
+            // 
+            // condutorToolStripMenuItem
+            // 
+            this.condutorToolStripMenuItem.Name = "condutorToolStripMenuItem";
+            this.condutorToolStripMenuItem.Size = new System.Drawing.Size(191, 26);
+            this.condutorToolStripMenuItem.Text = "Condutor";
+            this.condutorToolStripMenuItem.Click += new System.EventHandler(this.condutorToolStripMenuItem_Click);
             // 
             // toolbox
             // 
@@ -142,7 +156,7 @@
             this.labelTipoCadastro});
             this.toolbox.Location = new System.Drawing.Point(0, 30);
             this.toolbox.Name = "toolbox";
-            this.toolbox.Size = new System.Drawing.Size(1211, 41);
+            this.toolbox.Size = new System.Drawing.Size(1168, 41);
             this.toolbox.TabIndex = 1;
             this.toolbox.Text = "toolStrip1";
             // 
@@ -244,10 +258,10 @@
             this.statusStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.labelRodape});
-            this.statusStrip1.Location = new System.Drawing.Point(0, 1029);
+            this.statusStrip1.Location = new System.Drawing.Point(0, 535);
             this.statusStrip1.Name = "statusStrip1";
             this.statusStrip1.Padding = new System.Windows.Forms.Padding(1, 0, 16, 0);
-            this.statusStrip1.Size = new System.Drawing.Size(1211, 26);
+            this.statusStrip1.Size = new System.Drawing.Size(1168, 26);
             this.statusStrip1.TabIndex = 2;
             this.statusStrip1.Text = "statusStrip1";
             // 
@@ -263,35 +277,21 @@
             this.panelRegistros.Location = new System.Drawing.Point(0, 71);
             this.panelRegistros.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.panelRegistros.Name = "panelRegistros";
-            this.panelRegistros.Size = new System.Drawing.Size(1211, 958);
+            this.panelRegistros.Size = new System.Drawing.Size(1168, 464);
             this.panelRegistros.TabIndex = 3;
-            // 
-            // clienteToolStripMenuItem
-            // 
-            this.clienteToolStripMenuItem.Name = "clienteToolStripMenuItem";
-            this.clienteToolStripMenuItem.Size = new System.Drawing.Size(224, 26);
-            this.clienteToolStripMenuItem.Text = "Cliente";
-            this.clienteToolStripMenuItem.Click += new System.EventHandler(this.clienteToolStripMenuItem_Click);
-            // 
-            // condutorToolStripMenuItem
-            // 
-            this.condutorToolStripMenuItem.Name = "condutorToolStripMenuItem";
-            this.condutorToolStripMenuItem.Size = new System.Drawing.Size(224, 26);
-            this.condutorToolStripMenuItem.Text = "Condutor";
-            this.condutorToolStripMenuItem.Click += new System.EventHandler(this.condutorToolStripMenuItem_Click);
             // 
             // TelaPrincipalForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1211, 1055);
+            this.ClientSize = new System.Drawing.Size(1168, 561);
             this.Controls.Add(this.panelRegistros);
             this.Controls.Add(this.statusStrip1);
             this.Controls.Add(this.toolbox);
             this.Controls.Add(this.menu);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.MainMenuStrip = this.menu;
             this.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
-            this.MinimumSize = new System.Drawing.Size(1227, 1078);
             this.Name = "TelaPrincipalForm";
             this.ShowIcon = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;


### PR DESCRIPTION
Nesta atualização foi corrigido certos componentes de tela como:
- Telas centralizadas
- Não permitir redimensionar
- Campo de número readonly
- Corrigir maskedbox
- TabIndex das telas
- Corrigir ordem validadores de acordo com a tela

Além de uma pequena validação para o **Módulo de Condutor**, que estava _permitindo a inserção de um Condutor sem um Cliente selecionado_, causando assim uma inconsistência no cadastro.